### PR TITLE
release 1.0.1

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B clean package --file pom.xml
     - uses: actions/upload-artifact@v4
       with:
         name: lands-outposts

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # lands-outposts
+
+Lands addon for Towny Outposts equivalent (Paper 1.21.1).
+
+### Towny Outposts migration
+
+Run Lands import command then `/lands-outposts import-towny-outposts` from console.
+Towny needs to be enabled for this command to work.

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
     <build>
         <finalName>lands-outposts</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
     <repositories>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
-        </repository>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+          </repository>
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.laboulangerie</groupId>
     <artifactId>lands-outposts</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1</version>
 
     <name>Lands-Outposts</name>
     <url>https://github.com/LaBoulangerie/lands-outposts</url>

--- a/src/main/java/net/laboulangerie/landsoutposts/command/ListCommand.java
+++ b/src/main/java/net/laboulangerie/landsoutposts/command/ListCommand.java
@@ -76,6 +76,12 @@ public class ListCommand {
 
     private final void executes(LandPlayer landPlayer, Collection<? extends Land> lands) {
         Player player = landPlayer.getPlayer();
+
+        if (lands.isEmpty()) {
+            player.sendRichMessage(LandsOutposts.LANDSOUTPOSTS_BASE_MSG + LandsOutpostsLanguage.LANG.notInALand);
+            return;
+        }
+
         try {
             HashMap<String,LandOutpost> outposts = this.landsOutposts.getPlayerLandsOutposts(landPlayer, false);
             for (Land land : lands) {

--- a/src/main/java/net/laboulangerie/landsoutposts/command/TeleportCommand.java
+++ b/src/main/java/net/laboulangerie/landsoutposts/command/TeleportCommand.java
@@ -2,7 +2,9 @@ package net.laboulangerie.landsoutposts.command;
 
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -28,11 +30,13 @@ public class TeleportCommand {
         this.commandCooldown = new HashMap<>();
         landsOutposts.getServer().getScheduler().runTaskTimerAsynchronously(landsOutposts, () -> {
             LandsOutposts.debugMsg("Cooldown cleanup task.");
-            for (Map.Entry<UUID,Long> entry : commandCooldown.entrySet()) {
+            Iterator it = commandCooldown.entrySet().iterator();
+            while(it.hasNext()){
+                Map.Entry<UUID,Long> entry = (Entry<UUID, Long>) it.next();
                 if ((System.currentTimeMillis() - entry.getValue()) > (LandsOutpostsConfiguration.CONF.outpostsTeleportCooldown * 1000)) {
-                    commandCooldown.remove(entry.getKey());
+                    it.remove();
                 }
-            } 
+            }
         }, 72000, 72000);
     }
 


### PR DESCRIPTION
f2b0bd85a10b06a2de06e3f9a946342458c5d8d7: outpost list cmd: display err msg if no land
2d57e317a8ec171558ba70838d7da60b4af5da41: fix ConcurrentModificationException on cooldown cleanup task

```
[15:02:11] [Craft Scheduler Thread - 1141 - lands-outposts/INFO]: [lands-outposts] DEBUG Cooldown cleanup task.
[15:02:11] [Craft Scheduler Thread - 1141 - lands-outposts/WARN]: [lands-outposts] Plugin lands-outposts v1.0-SNAPSHOT generated an exception while executing task 646
java.util.ConcurrentModificationException: null
    at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1605) ~[?:?]
    at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1638) ~[?:?]
    at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1636) ~[?:?]
    at lands-outposts.jar/net.laboulangerie.landsoutposts.command.TeleportCommand.lambda$new$0(TeleportCommand.java:31) ~[lands-outposts.jar:?]
    at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:86) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
    at org.bukkit.craftbukkit.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
    at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[purpur-1.21.1.jar:?]
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
    at java.base/java.lang.Thread.run(Thread.java:1570) ~[?:?]
```